### PR TITLE
State correct environment variable in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,6 +372,6 @@ c.GenericOAuthenticator.extra_params = {
     'client_secret': 'MOODLE-CLIENT-SECRET-KEY'}
 ```
 
-And set your environmental variable `_OAUTH_AUTHORIZE_URL` to:
+And set your environmental variable `OAUTH2_AUTHORIZE_URL` to:
 
 `http://YOUR-MOODLE-DOMAIN.com/local/oauth/login.php?client_id=MOODLE-CLIENT-ID&response_type=code`


### PR DESCRIPTION
`_OAUTH_AUTHORIZE_URL` is the internal variable holding the content of the environment variable `OAUTH2_AUTHORIZE_URL` (see `generic.GenericEnvMixin`). Therefore `OAUTH2_AUTHORIZE_URL` must be stated here instead of `_OAUTH_AUTHORIZE_URL`.

See issue #230.